### PR TITLE
nc as a dependency

### DIFF
--- a/zookeeper.spec
+++ b/zookeeper.spec
@@ -16,7 +16,7 @@ Source4: log4j.properties
 Source5: java.env
 BuildRoot: %{_tmppath}/%{name}-%{rel_ver}-%{release}-root
 BuildRequires: python-devel,gcc,make,libtool,autoconf,cxxtest,cppunit-devel,cppunit
-Requires: logrotate, java
+Requires: logrotate, java, nc
 Requires(post): chkconfig initscripts
 Requires(pre): chkconfig initscripts
 AutoReqProv: no


### PR DESCRIPTION
nc is used in the init script to check the status of the zookeeper cluster.
When it isn't there the init script doesn't return a correct status
