### PR TITLE
fix issue with rpm owning /usr/bin and /usr/sbin

### DIFF
--- a/zookeeper.spec
+++ b/zookeeper.spec
@@ -92,8 +92,9 @@ rm -rf %{buildroot}
 %{_initrddir}/zookeeper
 %config(noreplace) %{_sysconfdir}/logrotate.d/zookeeper
 %config(noreplace) %{_sysconfdir}/zookeeper
-%{_sbindir}
-%{_bindir}
+%{_bindir}/cli_mt
+%{_bindir}/cli_st
+%{_bindir}/load_gen
 
 # ------------------------------ libzookeeper ------------------------------
 


### PR DESCRIPTION
Centos 7.1  rpm  4.11.1 doesn't like when rpms own /usr/bin and /usr/sbin
Transaction check error:
  file /usr/bin from install of zookeeper-3.4.5-2.x86_64 conflicts with file from package filesystem-3.2-18.el7.x86_64
  file /usr/sbin from install of zookeeper-3.4.5-2.x86_64 conflicts with file from package filesystem-3.2-18.el7.x86_64
