### PR TITLE
upstream project dropped this file, which caused builds to fail

### DIFF
--- a/zookeeper.spec
+++ b/zookeeper.spec
@@ -83,7 +83,7 @@ rm -rf %{buildroot}
 
 %files
 %defattr(-,root,root,-)
-%doc LICENSE.txt NOTICE.txt README.md
+%doc LICENSE.txt NOTICE.txt
 %doc docs recipes
 %dir %attr(0750, zookeeper, zookeeper) %{_localstatedir}/lib/zookeeper
 %dir %attr(0750, zookeeper, zookeeper) %{_localstatedir}/lib/zookeeper/data


### PR DESCRIPTION
I had to comment out the below in the spec file for mock to be able to build the code. 

Mock 1.4.9 on OEL 7.4 (note OEL 7 requires --old-chroot due to previously mentioned systemd error)