### PR TITLE
systemd: restrict write access to system directories

### DIFF
--- a/zookeeper.service
+++ b/zookeeper.service
@@ -22,6 +22,7 @@ StandardOutput=journal
 StandardError=journal
 SuccessExitStatus=130
 KillSignal=SIGINT
+ProtectSystem=full
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
there are no reasons to allow zookeeper service write access to
system directories, like /etc, /boot, /usr ...